### PR TITLE
feat: unwrap errors in Get

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Leven Labs Inc.
+Copyright (c) 2025 Leven Labs Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Later on you can get the userID back:
 userID, ok := errctx.Get(err, "userID").(int64)
 ```
 
-If you want to check the original error object:
+If you want to check the wrapped error object:
 ```
-if errors.Is(err, mgo.ErrNotFound) {
+if errors.Is(err, underlyingError) {
 
 }
 ```

--- a/errctx.go
+++ b/errctx.go
@@ -56,7 +56,6 @@ func Base(err error) error {
 //	err3 := errctx.Set(err2, "foo", "b")
 //	fmt.Println(errctx.Get(err2, "foo")) // "a"
 //	fmt.Println(errctx.Get(err3, "foo")) // "b"
-//
 func Set(err error, kvs ...interface{}) error {
 	ec := errctx{
 		err: Base(err),
@@ -74,15 +73,44 @@ func Set(err error, kvs ...interface{}) error {
 	return ec
 }
 
+func get(err error, k interface{}) (interface{}, bool) {
+	for {
+		if ec, ok := err.(errctx); ok {
+			if v, ok := ec.ctx[k]; ok {
+				return v, ok
+			}
+		}
+		switch x := err.(type) {
+		case interface{ Unwrap() error }:
+			err = x.Unwrap()
+			if err == nil {
+				return nil, false
+			}
+		case interface{ Unwrap() []error }:
+			for _, err := range x.Unwrap() {
+				if err == nil {
+					continue
+				}
+				if v, ok := get(err, k); ok {
+					return v, ok
+				}
+			}
+			return nil, false
+		default:
+			return nil, false
+		}
+	}
+}
+
 // Get retrieves the value associated with the key by a previous call to Set,
 // which this error should have been returned from. Returns nil if the key isn't
 // set, or if the error wasn't previously wrapped by Set at all.
+//
+// This will traverse the error chain until it finds an error returned by Set
+// that contains the key.
 func Get(err error, k interface{}) interface{} {
-	ec, ok := err.(errctx)
-	if !ok {
-		return nil
-	}
-	return ec.ctx[k]
+	v, _ := get(err, k)
+	return v
 }
 
 // Mark records the filename and line number that called Mark and sets it on
@@ -94,6 +122,8 @@ func Mark(err error) error {
 // MarkSkip is like Mark but allows you to skip an arbitrary amount of
 // functions from the stack. Sending skip of 0 means to Mark the caller of this
 // function.
+//
+// Returns nil if the sent error is nil.
 func MarkSkip(err error, skip int) error {
 	if err == nil {
 		return nil
@@ -114,10 +144,9 @@ func MarkSkip(err error, skip int) error {
 // Line returns the file and line number where Mark was first called on the
 // error and a boolean indicating if any line was found.
 func Line(err error) (string, bool) {
-	ec, ok := err.(errctx)
+	v, ok := get(err, sourceKey(0))
 	if !ok {
 		return "", false
 	}
-	s, ok := ec.ctx[sourceKey(0)].(string)
-	return s, ok
+	return v.(string), true
 }

--- a/errctx_test.go
+++ b/errctx_test.go
@@ -4,15 +4,39 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
-	. "testing"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+type wrapErr struct {
+	err error
+}
+
+func (e wrapErr) Error() string {
+	return e.err.Error()
+}
+
+func (e wrapErr) Unwrap() error {
+	return e.err
+}
+
+type wrapErrs struct {
+	errs []error
+}
+
+func (e wrapErrs) Error() string {
+	return fmt.Sprintf("%v", e.errs)
+}
+
+func (e wrapErrs) Unwrap() []error {
+	return e.errs
+}
+
 type key int
 
-func TestErrCtx(t *T) {
+func TestErrCtx(t *testing.T) {
 	err := errors.New("foo")
 
 	assert.Equal(t, err, Base(err))
@@ -45,9 +69,42 @@ func TestErrCtx(t *T) {
 	assert.True(t, err3.(errctx).Is(err3))
 	assert.True(t, err3.(errctx).Is(err2))
 	assert.True(t, err3.(errctx).Is(err2.(errctx).err))
+
+	err4 := wrapErr{err: err3}
+	assert.Equal(t, err4, Base(err4))
+	assert.Nil(t, Get(err4, key(0)))
+	assert.Equal(t, "b", Get(err4, key(1)))
+
+	err5 := Set(err4, key(3), "d")
+	assert.Equal(t, err4, Base(err5))
+	assert.Nil(t, Get(err5, key(0)))
+	assert.Equal(t, "b", Get(err5, key(1)))
+	assert.Equal(t, "c", Get(err5, key(2)))
+	assert.Equal(t, "d", Get(err5, key(3)))
+
+	err6 := wrapErrs{errs: []error{wrapErr{err: err5}, err1}}
+	assert.Equal(t, err6, Base(err6))
+	assert.Equal(t, "a", Get(err6, key(0)))
+	assert.Equal(t, "b", Get(err6, key(1)))
+	assert.Equal(t, "c", Get(err6, key(2)))
+	assert.Equal(t, "d", Get(err6, key(3)))
+
+	err7 := Set(err6, key(4), "e")
+	assert.Equal(t, err6, Base(err7))
+	assert.Equal(t, "a", Get(err7, key(0)))
+	assert.Equal(t, "b", Get(err7, key(1)))
+	assert.Equal(t, "c", Get(err7, key(2)))
+	assert.Equal(t, "d", Get(err7, key(3)))
+	assert.Equal(t, "e", Get(err7, key(4)))
+
+	assert.Nil(t, Get(wrapErr{}, key(0)))
+	assert.Nil(t, Get(wrapErrs{}, key(0)))
+	assert.Nil(t, Get(wrapErrs{errs: []error{nil}}, key(0)))
+	assert.Equal(t, "a", Get(wrapErrs{errs: []error{nil, err1}}, key(0)))
+	assert.Nil(t, Get(nil, key(0)))
 }
 
-func TestMark(t *T) {
+func TestMark(t *testing.T) {
 	err := errors.New("bar")
 
 	l, ok := Line(err)
@@ -58,6 +115,9 @@ func TestMark(t *T) {
 	require.True(t, ok)
 	err = Mark(err)
 	l, ok = Line(err)
+	assert.True(t, ok)
+	assert.Equal(t, fmt.Sprintf("errctx_test.go:%d", ln+2), l)
+	l, ok = Line(wrapErr{err: err})
 	assert.True(t, ok)
 	assert.Equal(t, fmt.Sprintf("errctx_test.go:%d", ln+2), l)
 
@@ -76,4 +136,9 @@ func TestMark(t *T) {
 	l, ok = Line(err)
 	assert.True(t, ok)
 	assert.Equal(t, fmt.Sprintf("errctx_test.go:%d", ln-1), l)
+
+	assert.Nil(t, Mark(nil))
+	assert.Nil(t, MarkSkip(nil, 1))
+	_, ok = Line(nil)
+	assert.False(t, ok)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,9 @@ module github.com/levenlabs/errctx
 
 go 1.15
 
+require github.com/stretchr/testify v1.7.0
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -7,8 +6,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Instead of just looking at the top-most error, unwrap them until we find the specified key.

This prevents keys/values from being lost if an intermediary doesn't know about errctx and ends up wrapping the error.